### PR TITLE
Add indicator window ETL doc & cleanup

### DIFF
--- a/etl_indicator_window.py
+++ b/etl_indicator_window.py
@@ -1,3 +1,5 @@
+"""ETL job to compute a rolling window of indicators for each timeframe.
+Results are stored in the market_indicators table for use by tools like get_last_n_indicators."""
 import os, json, math, asyncio, logging
 from typing import List
 from dotenv import load_dotenv

--- a/etl_indicators.py
+++ b/etl_indicators.py
@@ -21,7 +21,6 @@ SYMBOL         = os.getenv("SYMBOL", "CORE/USDT:USDT")
 TF_LIST        = ["1m", "5m", "15m", "1h", "4h", "1d"]
 LIMIT          = 200
 HISTORY_LENGTH = int(os.getenv("HISTORY_LENGTH", 200))  # Increased from 7 to 30 for richer historical context
-LOOKBACK_WINDOW = int(os.getenv("LOOKBACK_WINDOW", 30))  # uniform model look-back
 
 DB_URL         = os.getenv("TIMESCALEDB_URL")
 API_KEY        = os.getenv("BYBIT_API_KEY")


### PR DESCRIPTION
## Summary
- document the rolling indicator window job
- remove unused LOOKBACK_WINDOW constant from main indicators ETL

## Testing
- `python -m py_compile etl_indicator_window.py etl_indicators.py timescaledb_tools.py ai_trade_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5a551eb88325b7b556f24bca6e44