### PR TITLE
Fix market context history series bug

### DIFF
--- a/ai_trade_agent.py
+++ b/ai_trade_agent.py
@@ -24,7 +24,7 @@ except ImportError:
 import ccxt
 # Updated agents import for AgentHooks, RunContextWrapper, trace, Tool
 from agents import Agent, ModelSettings, Runner, function_tool, handoff, AgentHooks, RunContextWrapper, trace, Tool
-from timescaledb_tools import _get_latest_indicators_multi, get_last_n_indicators
+from timescaledb_tools import _get_latest_indicators_multi
 from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
 from tools import get_orderbook_snapshot, get_derivatives_metrics
 

--- a/timescaledb_tools.py
+++ b/timescaledb_tools.py
@@ -81,10 +81,19 @@ def get_last_n_vol_state(symbol: str, timeframe: str, n: int = 30) -> list:
     conn.close()
     return [float(r[0]) for r in rows if r[0] is not None]
 
-@function_tool
-def get_last_n_indicators(symbol: str, timeframe: str, n: int = 30) -> list:
+def _get_last_n_indicators(symbol: str, timeframe: str, n: int = 30) -> list:
     """Return the last n indicator rows for a symbol/timeframe."""
-    tf_map = {"1 m": "1m", "5 m": "5m", "15 m": "15m", "1m": "1m", "5m": "5m", "15m": "15m", "1h": "1h", "4h": "4h", "1d": "1d"}
+    tf_map = {
+        "1 m": "1m",
+        "5 m": "5m",
+        "15 m": "15m",
+        "1m": "1m",
+        "5m": "5m",
+        "15m": "15m",
+        "1h": "1h",
+        "4h": "4h",
+        "1d": "1d",
+    }
     timeframe = tf_map.get(timeframe.strip(), timeframe.replace(" ", ""))
     conn = get_timescaledb_conn()
     cur = conn.cursor()
@@ -92,13 +101,15 @@ def get_last_n_indicators(symbol: str, timeframe: str, n: int = 30) -> list:
         '''SELECT indicators FROM market_indicators
            WHERE symbol = %s AND timeframe = %s
            ORDER BY timestamp DESC LIMIT %s''',
-        (symbol, timeframe, n)
+        (symbol, timeframe, n),
     )
     rows = cur.fetchall()
     cur.close()
     conn.close()
     # Return oldest first for easier modeling
     return [r[0] for r in rows[::-1]]
+
+get_last_n_indicators = function_tool(_get_last_n_indicators)
 
 def _get_all_history_series(n_max_ratio: int = 30, n_bb_width: int = 20) -> dict:
     """
@@ -153,4 +164,4 @@ def _get_all_history_series(n_max_ratio: int = 30, n_bb_width: int = 20) -> dict
 
 get_all_history_series = function_tool(_get_all_history_series)
 get_all_history_series_py = _get_all_history_series
-get_last_n_indicators_py = get_last_n_indicators
+get_last_n_indicators_py = _get_last_n_indicators


### PR DESCRIPTION
## Summary
- fix callable alias for `get_last_n_indicators`
- clean up imports

## Testing
- `python -m py_compile timescaledb_tools.py ai_trade_agent.py etl_indicator_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f77dcf2e483259e264bf2c78e4846