### PR TITLE
Reduce market context payload

### DIFF
--- a/ai_trade_agent.py
+++ b/ai_trade_agent.py
@@ -319,8 +319,9 @@ def get_market_context(symbol: str, timeframes: list[str]) -> dict:
         import timescaledb_tools
         ctx.update(timescaledb_tools.get_all_history_series_py())
         win = {}
+        window_size = int(os.getenv("INDICATOR_WINDOW_SIZE", 10))
         for tf in timeframes:
-            win[tf] = timescaledb_tools.get_last_n_indicators_py(symbol, tf, 30)
+            win[tf] = timescaledb_tools.get_last_n_indicators_py(symbol, tf, window_size)
         ctx["indicator_window"] = win
     except Exception as e:
         ctx["history_series_error"] = str(e)

--- a/tools.py
+++ b/tools.py
@@ -182,6 +182,14 @@ def get_orderbook_snapshot(symbol: str = "ETH/USDT:USDT"):
     if not data:
         raise RuntimeError("Malformed orderbook entry in Redis")
     snap = json.loads(data)
+    # Trim heavy arrays to keep context lightweight
+    for key in ["history", "depth_heat_bid", "depth_heat_ask"]:
+        if key in snap:
+            # Keep only last 10 history entries if present
+            if key == "history" and isinstance(snap[key], list):
+                snap[key] = snap[key][-10:]
+            else:
+                snap.pop(key, None)
     return snap
 
 def get_derivatives_metrics(symbol: str):


### PR DESCRIPTION
## Summary
- limit indicator window size via `INDICATOR_WINDOW_SIZE` env var (default 10)
- trim orderbook snapshot heavy arrays before returning

## Testing
- `python -m py_compile ai_trade_agent.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7b213d988325b43fc6669c91ccfa