### PR TITLE
Improve TA agent JSON handoff instructions

### DIFF
--- a/ai_trade_agent.py
+++ b/ai_trade_agent.py
@@ -596,7 +596,9 @@ Guiding principles
 • No static thresholds — rely on computed probabilities.
 • Perform every calculation in the Python code interpreter.
 • Aim for the best entry price rather than chasing moves.
-• Print the JSON and call the handoff tool. Nothing more.
+• After self-QA, output exactly one JSON object using the schema.
+• Immediately call the handoff tool with that JSON and nothing else.
+• Never finish without a JSON signal; if analysis fails return the WAIT JSON and still handoff.
 
 Think rigorously → Model quantitatively → Self-QA → Emit JSON → Handoff.
 """


### PR DESCRIPTION
## Summary
- enforce that the TechnicalAnalyst prints exactly one JSON block
- call the handoff tool immediately with that JSON or a WAIT object if analysis fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840be847de48325af6d77eee08366e1